### PR TITLE
Add defined statement

### DIFF
--- a/includes/modules/product_listing.php
+++ b/includes/modules/product_listing.php
@@ -94,7 +94,7 @@
       </div>
 
     <?php
-    if ( (MODULE_HEADER_TAGS_GRID_LIST_VIEW_STATUS == 'True') && (strpos(MODULE_HEADER_TAGS_GRID_LIST_VIEW_PAGES, basename($PHP_SELF)) !== false) ) {
+    if ( (defined('MODULE_HEADER_TAGS_GRID_LIST_VIEW_STATUS') && MODULE_HEADER_TAGS_GRID_LIST_VIEW_STATUS == 'True') && (strpos(MODULE_HEADER_TAGS_GRID_LIST_VIEW_PAGES, basename($PHP_SELF)) !== false) ) {
       ?>
       <strong><?php echo TEXT_VIEW; ?></strong>
       <div class="btn-group">


### PR DESCRIPTION
If the header tag module "Grid List Javascript (jQuery)" is not installed, the constant "MODULE_HEADER_TAGS_GRID_LIST_VIEW_STATUS" is  not defined and shows an undefined constant error.